### PR TITLE
Support platform "Linux/UNIX (Amazon VPC)"

### DIFF
--- a/checks.d/aws_ec2_count.py
+++ b/checks.d/aws_ec2_count.py
@@ -209,7 +209,7 @@ class InstanceFetcher():
         reserved_instances = self.__ec2.describe_reserved_instances(
             Filters=[
                 { 'Name' : 'state',               'Values' : [ 'active' ] },
-                { 'Name' : 'product-description', 'Values' : [ 'Linux/UNIX' ] },
+                { 'Name' : 'product-description', 'Values' : [ 'Linux/UNIX', 'Linux/UNIX (Amazon VPC)' ] },
                 { 'Name' : 'instance-tenancy',    'Values' : [ 'default' ] },
             ],
         )


### PR DESCRIPTION
Accounts signed up before May 2013 can select not only `Linux/UNIX` but also `Linux/UNIX (Amazon VPC)`.
`Linux/UNIX (Amazon VPC)` means the same as `Linux/UNIX` for accounts who signed up after May 2013.

ref https://dev.classmethod.jp/cloud/aws/purchase-ec2-classic-reserved-instance/