### PR TITLE
Add missing instance size and normalization factor

### DIFF
--- a/checks.d/aws_ec2_count.py
+++ b/checks.d/aws_ec2_count.py
@@ -17,8 +17,12 @@ class NormalizationFactor():
     __nf['2xlarge']  =  16.0
     __nf['4xlarge']  =  32.0
     __nf['8xlarge']  =  64.0
+    __nf['9xlarge']  =  72.0
     __nf['10xlarge'] =  80.0
+    __nf['12xlarge'] =  96.0
     __nf['16xlarge'] = 128.0
+    __nf['18xlarge'] = 144.0
+    __nf['24xlarge'] = 192.0
     __nf['32xlarge'] = 256.0
 
     @classmethod

--- a/tests/test_aws_ec2_count.py
+++ b/tests/test_aws_ec2_count.py
@@ -20,8 +20,12 @@ class TestNormalizationFactor(unittest.TestCase):
                 '2xlarge',
                 '4xlarge',
                 '8xlarge',
+                '9xlarge',
                 '10xlarge',
+                '12xlarge',
                 '16xlarge',
+                '18xlarge',
+                '24xlarge',
                 '32xlarge',
             ]
         )


### PR DESCRIPTION
Found the following error.

```
2019-08-24 12:40:11 UTC | ERROR | dd.collector | checks.aws_ec2_count(__init__.py:841) | Check 'aws_ec2_count' instance #0 failed
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/checks/__init__.py", line 824, in run
    self.check(copy.deepcopy(instance))
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 318, in check
    reserved_instances = fetcher.get_reserved_instances()
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 246, in get_reserved_instances
    reserved_instance['InstanceType'],
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 132, in get_itype
    return self.get(az, family, size)
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 126, in get
    self.__instances[az][family][size] = InstanceCounter(NormalizationFactor.get_value(size))
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 31, in get_value
    raise TypeError('unknown instance size : {}'.format(size))
TypeError: unknown instance size : 12xlarge
```