### PR TITLE
Support 3xlarge and 6xlarge instance size

### DIFF
--- a/checks.d/aws_ec2_count.py
+++ b/checks.d/aws_ec2_count.py
@@ -16,6 +16,7 @@ class NormalizationFactor():
     __nf['xlarge']   =   8.0
     __nf['2xlarge']  =  16.0
     __nf['4xlarge']  =  32.0
+    __nf['6xlarge']  =  48.0
     __nf['8xlarge']  =  64.0
     __nf['9xlarge']  =  72.0
     __nf['10xlarge'] =  80.0

--- a/checks.d/aws_ec2_count.py
+++ b/checks.d/aws_ec2_count.py
@@ -15,6 +15,7 @@ class NormalizationFactor():
     __nf['large']    =   4.0
     __nf['xlarge']   =   8.0
     __nf['2xlarge']  =  16.0
+    __nf['3xlarge']  =  24.0
     __nf['4xlarge']  =  32.0
     __nf['6xlarge']  =  48.0
     __nf['8xlarge']  =  64.0

--- a/tests/test_aws_ec2_count.py
+++ b/tests/test_aws_ec2_count.py
@@ -19,6 +19,7 @@ class TestNormalizationFactor(unittest.TestCase):
                 'xlarge',
                 '2xlarge',
                 '4xlarge',
+                '6xlarge',
                 '8xlarge',
                 '9xlarge',
                 '10xlarge',

--- a/tests/test_aws_ec2_count.py
+++ b/tests/test_aws_ec2_count.py
@@ -18,6 +18,7 @@ class TestNormalizationFactor(unittest.TestCase):
                 'large',
                 'xlarge',
                 '2xlarge',
+                '3xlarge',
                 '4xlarge',
                 '6xlarge',
                 '8xlarge',


### PR DESCRIPTION
Similar with https://github.com/mixi-inc/datadog-aws-ec2-counter/pull/7

```
2019-11-26 02:57:26 UTC | ERROR | dd.collector | checks.aws_ec2_count(__init__.py:841) | Check 'aws_ec2_count' instance #0 failed
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/checks/__init__.py", line 824, in run
    self.check(copy.deepcopy(instance))
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 327, in check
    running_instances = fetcher.get_running_instances()
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 200, in get_running_instances
    running_instance['InstanceType'],
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 136, in get_itype
    return self.get(az, family, size)
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 130, in get
    self.__instances[az][family][size] = InstanceCounter(NormalizationFactor.get_value(size))
  File "/etc/dd-agent/checks.d/aws_ec2_count.py", line 35, in get_value
    raise TypeError('unknown instance size : {}'.format(size))
TypeError: unknown instance size : 6xlarge
```

@isaoshimizu Please review and merge